### PR TITLE
Added pie chart for goal progress and shade Days off card orange if projected to have less than 0 days of rest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "run-metrics",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.4.15"
+        "chart.js": "^4.5.0",
+        "vue": "^3.4.15",
+        "vue-chartjs": "^5.3.2"
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
@@ -2050,6 +2052,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
@@ -2963,6 +2971,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/color-convert": {
@@ -5756,6 +5776,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.2.tgz",
+      "integrity": "sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-template-compiler": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.4.15"
+    "chart.js": "^4.5.0",
+    "vue": "^3.4.15",
+    "vue-chartjs": "^5.3.2"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/src/components/GoalProgressChart.vue
+++ b/src/components/GoalProgressChart.vue
@@ -1,0 +1,132 @@
+<template>
+  <div v-if="currentMiles !== null && goalMiles !== null && goalMiles > 0" class="goal-progress-chart">
+    <canvas ref="chartCanvas" width="80" height="80"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch, nextTick, onUnmounted } from 'vue';
+import { Chart, ArcElement, Tooltip, Legend, DoughnutController } from 'chart.js';
+
+// Register Chart.js components
+Chart.register(ArcElement, Tooltip, Legend, DoughnutController);
+
+const props = defineProps<{
+  currentMiles: number;
+  goalMiles: number;
+}>();
+
+const chartCanvas = ref<HTMLCanvasElement>();
+let chart: Chart | null = null;
+
+const createChart = () => {
+  if (!chartCanvas.value) {
+    console.log('Canvas ref not available');
+    return;
+  }
+
+  const ctx = chartCanvas.value.getContext('2d');
+  if (!ctx) {
+    return;
+  }
+
+  // Don't create chart if we don't have valid data
+  if (props.currentMiles === null || props.goalMiles === null || props.goalMiles <= 0) {
+    return;
+  }
+
+  let progress = Math.min((props.currentMiles / props.goalMiles) * 100, 100);
+  let remaining = Math.max(100 - progress, 0);
+
+  // Ensure we have some data to render
+  if (progress === 0 && remaining === 0) {
+    progress = 0.1;
+    remaining = 99.9;
+  }
+
+  // Destroy existing chart if it exists
+  if (chart) {
+    chart.destroy();
+  }
+
+  chart = new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: ['Progress', 'Remaining'],
+      datasets: [{
+        data: [progress, remaining],
+        backgroundColor: [
+          '#4CAF50', // Green for progress
+          '#e0e0e0'  // Darker gray for remaining - more visible
+        ],
+        borderWidth: 0
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      cutout: '70%',
+      plugins: {
+        legend: {
+          display: false
+        },
+        tooltip: {
+          enabled: false
+        }
+      },
+      elements: {
+        arc: {
+          borderRadius: 4
+        }
+      }
+    }
+  });
+
+};
+
+const updateChart = () => {
+  if (!chart) {
+    return;
+  }
+
+  // Don't update if we don't have valid data
+  if (props.currentMiles === null || props.goalMiles === null || props.goalMiles <= 0) {
+    return;
+  }
+
+  let progress = Math.min((props.currentMiles / props.goalMiles) * 100, 100);
+  let remaining = Math.max(100 - progress, 0);
+
+  chart.data.datasets[0].data = [progress, remaining];
+  chart.update('none');
+};
+
+onMounted(() => {
+  nextTick(() => {
+    createChart();
+  });
+});
+
+onUnmounted(() => {
+  if (chart) {
+    chart.destroy();
+    chart = null;
+  }
+});
+
+watch(() => [props.currentMiles, props.goalMiles], () => {
+  if (chart) {
+    updateChart();
+  } else {
+    createChart();
+  }
+}, { deep: true });
+</script>
+
+<style scoped>
+.goal-progress-chart {
+  width: 80px;
+  height: 80px;
+  margin: 0 auto;
+}
+</style> 

--- a/src/components/RunInputForm.vue
+++ b/src/components/RunInputForm.vue
@@ -34,12 +34,14 @@ const emit = defineEmits<{
   (e: 'update:goal', value: number | null): void;
 }>();
 
-const milesRun = ref<number | null>(null);
+const milesRun = ref<number | null | string>(null);
 const goalMiles = ref<number | null>(null);
 const storedGoal = ref<number | null>(null);
 
 const updateMiles = () => {
-  emit('update:miles', milesRun.value);
+  // Convert empty string to null, otherwise convert to number
+  const value = milesRun.value === '' ? null : Number(milesRun.value);
+  emit('update:miles', value);
 };
 
 const saveGoal = () => {

--- a/src/components/RunStats.vue
+++ b/src/components/RunStats.vue
@@ -36,11 +36,18 @@
           <p class="stat-label">miles by year end</p>
         </div>
 
-        <!-- Third row: Rest Days (if applicable) -->
-        <div v-if="goal && projectedYearEnd >= goal" class="stat-card rest-days-card">
+        <!-- Third row: Rest Days or Warning -->
+        <div v-if="goal && !isBehindSchedule && projectedYearEnd >= goal" class="stat-card rest-days-card">
           <h3>Rest Days Available</h3>
           <p class="stat-value">{{ restDaysText }}</p>
           <p class="stat-label">you could take off</p>
+        </div>
+        
+        <!-- Warning card when behind schedule -->
+        <div v-if="goal && isBehindSchedule" class="stat-card warning-card">
+          <h3>Goal Status</h3>
+          <p class="stat-value">{{ projectedYearEnd.toFixed(1) }}</p>
+          <p class="stat-label">projected year end (goal: {{ goal }})</p>
         </div>
       </div>
     </article>
@@ -97,6 +104,18 @@ const restDaysText = computed(() => {
     const weeks = (possibleRestDays / 7).toFixed(1);
     return `${weeks} week${weeks === '1.0' ? '' : 's'}`;
   }
+});
+
+const isBehindSchedule = computed(() => {
+  if (!props.goal || !props.milesRun) return false;
+  
+  const remainingDays = daysInYear - daysSoFar.value;
+  const remainingMiles = props.goal - props.milesRun;
+  const requiredDailyMiles = remainingMiles / remainingDays;
+  const currentDailyMiles = props.milesRun / daysSoFar.value;
+  
+  // If we need more miles per day than we're currently averaging, we're behind
+  return currentDailyMiles < requiredDailyMiles;
 });
 </script>
 
@@ -180,6 +199,15 @@ const restDaysText = computed(() => {
 
 .rest-days-card .stat-value {
   color: #2e7d32;
+}
+
+.warning-card {
+  background-color: #fff3cd;
+  color: #856404;
+}
+
+.warning-card .stat-value {
+  color: #856404;
 }
 
 /* Mobile responsiveness */

--- a/src/components/RunStats.vue
+++ b/src/components/RunStats.vue
@@ -8,14 +8,19 @@
         <!-- First row: Total Miles and Yearly Goal Progress -->
         <div class="stat-card">
           <h3>Total Miles</h3>
-          <p class="stat-value">{{ milesRun.toFixed(1) }}</p>
+          <p class="stat-value">{{ milesRun?.toFixed(1) || '0.0' }}</p>
           <p class="stat-label">miles run this year</p>
         </div>
         
         <div v-if="goal" class="stat-card">
           <h3>Goal Progress</h3>
-          <p class="stat-value">{{ goalProgress }}%</p>
-          <p class="stat-label">{{ milesRun.toFixed(1) }} / {{ goal }} miles</p>
+          <div class="goal-progress-container">
+            <div class="goal-progress-text">
+              <p class="stat-value">{{ goalProgress }}%</p>
+              <p class="stat-label">{{ milesRun?.toFixed(1) || '0.0' }} / {{ goal }} miles</p>
+            </div>
+            <GoalProgressChart :current-miles="milesRun" :goal-miles="goal" />
+          </div>
         </div>
 
         <!-- Second row: Average Miles Per Day and Projected Year-End -->
@@ -44,6 +49,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import GoalProgressChart from './GoalProgressChart.vue';
 
 const props = defineProps<{
   milesRun: number | null;
@@ -147,6 +153,26 @@ const restDaysText = computed(() => {
   margin: 0;
 }
 
+.goal-progress-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.goal-progress-text {
+  flex: 1;
+  text-align: left;
+}
+
+.goal-progress-text .stat-value {
+  margin-bottom: 0.2125rem;
+}
+
+.goal-progress-text .stat-label {
+  margin: 0;
+}
+
 .rest-days-card {
   background-color: #e8f5e9;
   color: #2e7d32;
@@ -173,6 +199,15 @@ const restDaysText = computed(() => {
   
   .stat-card h3 {
     font-size: 0.85rem;
+  }
+  
+  .goal-progress-container {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  
+  .goal-progress-text {
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
This PR adds a pie chart to show the progress of the user's goal.  Additionally, the "Rest Days Available" card will turn more orange (with dark orange text) if the user is not projected to meet the goal by year's end.