### PR TITLE
Fixing pie chart not drawing when user types in miles too quickly

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.knakdb649u"
+    "revision": "0.gaht1lfvg9g"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/GoalProgressChart.vue
+++ b/src/components/GoalProgressChart.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch, nextTick, onUnmounted } from 'vue';
+import { ref, watch, onUnmounted, nextTick } from 'vue';
 import { Chart, ArcElement, Tooltip, Legend, DoughnutController } from 'chart.js';
 
 // Register Chart.js components
@@ -21,7 +21,6 @@ let chart: Chart | null = null;
 
 const createChart = () => {
   if (!chartCanvas.value) {
-    console.log('Canvas ref not available');
     return;
   }
 
@@ -85,27 +84,15 @@ const createChart = () => {
 };
 
 const updateChart = () => {
-  if (!chart) {
-    return;
+  // Always recreate the chart for reliable updates
+  if (chart) {
+    chart.destroy();
+    chart = null;
   }
-
-  // Don't update if we don't have valid data
-  if (props.currentMiles === null || props.goalMiles === null || props.goalMiles <= 0) {
-    return;
-  }
-
-  let progress = Math.min((props.currentMiles / props.goalMiles) * 100, 100);
-  let remaining = Math.max(100 - progress, 0);
-
-  chart.data.datasets[0].data = [progress, remaining];
-  chart.update('none');
+  createChart();
 };
 
-onMounted(() => {
-  nextTick(() => {
-    createChart();
-  });
-});
+
 
 onUnmounted(() => {
   if (chart) {
@@ -115,12 +102,20 @@ onUnmounted(() => {
 });
 
 watch(() => [props.currentMiles, props.goalMiles], () => {
-  if (chart) {
+  nextTick(() => {
+    // Destroy chart if data becomes invalid
+    if (props.currentMiles === null || props.goalMiles === null || props.goalMiles <= 0) {
+      if (chart) {
+        chart.destroy();
+        chart = null;
+      }
+      return;
+    }
+    
+    // Always recreate the chart for reliable updates
     updateChart();
-  } else {
-    createChart();
-  }
-}, { deep: true });
+  });
+}, { deep: true, immediate: true });
 </script>
 
 <style scoped>

--- a/src/components/GoalProgressChart.vue
+++ b/src/components/GoalProgressChart.vue
@@ -92,8 +92,6 @@ const updateChart = () => {
   createChart();
 };
 
-
-
 onUnmounted(() => {
   if (chart) {
     chart.destroy();


### PR DESCRIPTION
This PR addresses an issue where the pie chart would be animating/drawing during a user's inputting numbers and would not update correctly when these overlapped.  Now the pie chart redraws with each user input.